### PR TITLE
Fix `SliceString` with range [start, stop].

### DIFF
--- a/src/slice.js
+++ b/src/slice.js
@@ -90,7 +90,8 @@ class Slice {
     if (array.slice && (this.step == null || this.step === 1)) {
       const start = this.start == null ? undefined : this.start;
       const stop = this.stop == null ? undefined : this.stop;
-      extracted = array.slice(start, stop).split('');
+      extracted = array.slice(start, stop);
+      extracted = !Array.isArray(extracted) ? extracted.split('') : extracted;
     } else {
       extracted = this.indices(array)
         .map(index => array[index]);

--- a/src/slice.js
+++ b/src/slice.js
@@ -90,7 +90,7 @@ class Slice {
     if (array.slice && (this.step == null || this.step === 1)) {
       const start = this.start == null ? undefined : this.start;
       const stop = this.stop == null ? undefined : this.stop;
-      extracted = array.slice(start, stop);
+      extracted = array.slice(start, stop).split('');
     } else {
       extracted = this.indices(array)
         .map(index => array[index]);

--- a/test/test-slice-string.js
+++ b/test/test-slice-string.js
@@ -65,10 +65,17 @@ describe('SliceString', () => {
     assert(output == expectedOutput);
   });
 
-  it('should extract the odd elements from an array', () => {
+  it('should extract the odd elements from a string', () => {
     const input = new SliceString('hello');
     const expectedOutput = 'el';
     const output = input[[1,,2]];
+    assert(output == expectedOutput);
+  });
+
+  it('should extract the range from a string', () => {
+    const input = new SliceString('hello');
+    const expectedOutput = 'ell';
+    const output = input[[1,4]];
     assert(output == expectedOutput);
   });
 });


### PR DESCRIPTION
Without going to deep into the internals, it looks like when extracting the `SliceString` range with a start, stop. It evaluates to a string (and not an Array).

I believe the documentation example table with `string[1:-1]` would have failed as well.

This splits the extracted value, and adds a test.

_PS: Your Contributor License Agreement 404's._
- [ ] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://www.clahub.com/agreements/intoli/slice)

Closes #2 
